### PR TITLE
Rename mesh_bed_level.py to bed_mesh.py

### DIFF
--- a/config/printer-prusa-mk3.cfg
+++ b/config/printer-prusa-mk3.cfg
@@ -197,5 +197,5 @@ pins: !PB7
 [gcode_ext]
 enabled: True
 
-[mesh_bed_level]
+[bed_mesh]
 speed: 80


### PR DESCRIPTION
Changed naming conventions to match Klipper's naming conventions.  The GCODES have been changed to BED_MESH_CALIBRATE and BED_MESH_OUTPUT.  They each continue to have G80 and G81 aliases respectively